### PR TITLE
Update website after the Tokyo 2018 event

### DIFF
--- a/2018_tokyo.html
+++ b/2018_tokyo.html
@@ -77,11 +77,10 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <h3 class="section-heading">This event will take place in Tokyo on October 8th-10th 2018</h3>
+                    <h3 class="section-heading">This event took place in Tokyo on October 8th-10th 2018</h3>
                     <h4>Location: Tokyo</h4>
                     <h4>Three hack-/concept-days for Bitcoin Core and Lightning developers, hosted by Digital Garage.<br/>
                     <br/><br/>Invitation required. Registration mandatory.
-                    <br/><br/>If you are a contributor and wish to come, please contact <a href="mailto:steven.j.lee+coredev@gmail.com">Steve Lee</a></h4>
                     <hr class="light"/>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -80,9 +80,8 @@
             <div class="header-content-inner">
                 <h1>CORE<span style="font-weight:100;">DEV</span> EVENTS</h1>
                 <hr>
-                <p>Invitation only developer events for hacking together on Bitcoin-Core and related projects.</p>
+                <p>Invitation only developer events for hacking together on Bitcoin Core and related projects.</p>
                 <p>__No talks. No politics. Just code.__</p>
-		<p><strong style="color: white;">NEXT EVENT:<br /><a href="2018_tokyo.html" style="color:white;">8th - 10th October 2018 - Tokyo</a></strong></p>
                 <a href="#about" class="btn btn-primary btn-xl page-scroll">Find Out More</a>
             </div>
         </div>
@@ -92,11 +91,10 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <h2 class="section-heading">The Bitcoin-Core development team is distributed all over the world. Sometimes it's good to come together and discuss and work face to face.</h2>
+                    <h2 class="section-heading">Bitcoin Core developers are distributed all over the world. Sometimes it's good to come together and discuss and work face to face.</h2>
                     <hr class="light">
-                    <p class="text-faded">Next meeting<br />
-                        <a href="2018_tokyo.html" style="color:black;">8th - 10th October 2018 - Tokyo</a></p>
-                    <p class="text-faded">Last events <br />
+                    <p class="text-faded">Past events <br />
+                        <a href="2018_tokyo.html" style="color:black;">8th - 10th October 2018 - Tokyo</a><br />
                         <a href="2018_newyork.html" style="color:black;">5th - 7th March 2018 - New York</a><br />
                         <a href="2017_sf.html" style="color:black;">5th - 7th Sept 2017 - San Francisco</a><br />
                         <a href="2017_tokyo.html" style="color:black;">27th - 28th July 2017 - Tokyo</a><br />
@@ -157,7 +155,7 @@
                 <div class="col-lg-9 col-lg-offset-2 text-center">
                     <h2 class="section-heading">Who is organizing this?</h2>
                     <hr class="primary">
-                    <p>Past CoreDev hacking meetings have been organized by Jonas Schnelli and John Newbery. The Tokyo 2018 CoreDev hacking meeting is being organized by Steve Lee.</p>
+                    <p>Past CoreDev hacking meetings have been organized by Jonas Schnelli, John Newbery and Steve Lee.</p>
                     <p>If you require travel subsidy, contact us and we will individually discuss it with our sponsors.</p>
                 </div>
                 <div class="col-lg-3 col-lg-offset-3 text-center">

--- a/pastevents.html
+++ b/pastevents.html
@@ -77,7 +77,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <h2>Last Events</h2>
+                    <h2>Past Events</h2>
+                    <p><a href="2018_tokyo.html">Tokyo 08-10 October 2018</a></p>
                     <p><a href="2018_newyork.html">New York 05-07 March 2018</a></p>
                     <p><a href="2017_sf.html">San Francisco 05-07 September 2017</a></p>
                     <p><a href="2017_tokyo.html">Tokyo 27-28 July 2017</a></p>


### PR DESCRIPTION
Change Tokyo 2018 from 'Next Event' to 'Past Event'. A few other
tidy-ups.