### PR TITLE
readme: Add contact info for organizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ CoreDev events are developer events for hacking together on Bitcoin Core and
 related projects.
 
 Please contact one of the organizers ([Jonas Schnelli](mailto:dev@jonasschnelli.ch),
-[John Newbery](mailto:john@chaincode.com) and [Steve Lee](mailto:steven.j.lee+coredev@gmail.com))
-if you would like to help organizing or hosting a future event.
+[John Newbery](mailto:john@chaincode.com), [Steve Lee](mailto:steven.j.lee+coredev@gmail.com),
+[Mike Schmidt](mailto:schmidty@gmail.com)) if you would like to help organizing
+or hosting a future event.

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ Website for the CoreDev.tech days.
 CoreDev events are developer events for hacking together on Bitcoin Core and
 related projects.
 
-Please contact one of the organizers (Jonas Schnelli, John Newbery and Steve
-Lee) if you would like to help organizing or hosting a future event.
+Please contact one of the organizers ([Jonas Schnelli](mailto:dev@jonasschnelli.ch),
+[John Newbery](mailto:john@chaincode.com) and [Steve Lee](mailto:steven.j.lee+coredev@gmail.com))
+if you would like to help organizing or hosting a future event.


### PR DESCRIPTION
In case welcome, I noted that the contact info for the organizers is
present in the footer of the website, but not where it is referenced in
`README.md` in the GitHub repository.

Adding the links there as well in case people are discovering this via
GitHub, and would like to contact the organizers but weren't sure how.