### PR TITLE
index: Fix emboldened text

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
                 <h1>CORE<span style="font-weight:100;">DEV</span> EVENTS</h1>
                 <hr>
                 <p>Invitation only developer events for hacking together on Bitcoin Core and related projects.</p>
-                <p>__No talks. No politics. Just code.__</p>
+                <p><strong>No talks. No politics. Just code.</strong></p>
                 <a href="#about" class="btn btn-primary btn-xl page-scroll">Find Out More</a>
             </div>
         </div>


### PR DESCRIPTION
It seems that in the header of the homepage, the desired style for the
text that reads "No talks. No politics. Just code." was to be bold. This
is because it is surrounded by two underscores on each side, which would
be the syntax to make it bold, if it were markdown.

This removes the underscores and uses an HTML tag to achieve the effect
instead (if that is what was intended).

**Before:**

![image](https://user-images.githubusercontent.com/1130872/72435993-b5581d80-379f-11ea-917b-97c921c0956a.png)

**After:**

![image](https://user-images.githubusercontent.com/1130872/72436030-c9038400-379f-11ea-9ca1-4681786f79d9.png)
