### PR TITLE
index: Add missing meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="">
+    <meta name="description" content="Invitation only developer events for hacking together on Bitcoin Core and related projects. No talks. No politics. Just code.">
     <meta name="author" content="">
     <link rel="shortcut icon" href="img/bitcoin-favicon.png" />
 


### PR DESCRIPTION
The homepage is currently missing a [meta description](https://moz.com/learn/seo/meta-description). Meta descriptions are what search engines reference to generate descriptions for their search results. Not having one will make it less likely for this site to be found by users via search engines.

This adds a description using the header text from the top of the homepage.